### PR TITLE
fix: GPUsegmenter does not remove model_file from kwargs anymore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.11.10
+ - fix: GPUSegmenter does not remove model_file from passed kwargs anymore
 0.11.9
  - tests: make sure all segmenters have clear type definitions
 0.11.8

--- a/dcnum/segm/segmenter_gpu.py
+++ b/dcnum/segm/segmenter_gpu.py
@@ -11,9 +11,8 @@ from .segmenter import Segmenter
 class GPUSegmenter(Segmenter, abc.ABC):
     mask_postprocessing = False
 
-    def __init__(self, model_file=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(GPUSegmenter, self).__init__(*args, **kwargs)
-        self.model_path = self._get_model_path(model_file)
 
     @staticmethod
     def _get_model_path(model_file):


### PR DESCRIPTION
This MR resolves the issue where the GPUSegmenter removes the `model_file` key-value pair from the kwargs that are passed to its initialization.

Closes #7 