### PR TITLE
Remove nan-values in computed features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.12.1
+ - fix: feature computation produces nan-features
 0.12.0
  - ref: always use "spawn" for creating new processes to avoid race
    conditions with Python threading.Lock upon forking on POSIX

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.12.1
- - fix: feature computation produces nan-features
+ - fix: avoid NaN-valued features due to invalid contours
 0.12.0
  - ref: always use "spawn" for creating new processes to avoid race
    conditions with Python threading.Lock upon forking on POSIX

--- a/dcnum/feat/feat_moments/mt_legacy.py
+++ b/dcnum/feat/feat_moments/mt_legacy.py
@@ -24,6 +24,9 @@ def moments_based_features(mask, pixel_size):
     inert_ratio_cvx = np.copy(empty)
     inert_ratio_raw = np.copy(empty)
     inert_ratio_prnc = np.copy(empty)
+    # The following valid-array is not a real feature, but only
+    # used to figure out which events need to be removed due
+    # to invalid computed features, often due to invalid contours.
     valid = np.full(size, False)
 
     for ii in range(size):

--- a/dcnum/feat/feat_moments/mt_legacy.py
+++ b/dcnum/feat/feat_moments/mt_legacy.py
@@ -24,10 +24,13 @@ def moments_based_features(mask, pixel_size):
     inert_ratio_cvx = np.copy(empty)
     inert_ratio_raw = np.copy(empty)
     inert_ratio_prnc = np.copy(empty)
+    valid = np.full(size, False)
 
     for ii in range(size):
         cont_raw = contour_single_opencv(mask[ii])
         if len(cont_raw.shape) < 2:
+            continue
+        if cv2.contourArea(cont_raw) == 0:
             continue
         mu_raw = cv2.moments(cont_raw)
 
@@ -89,6 +92,7 @@ def moments_based_features(mask, pixel_size):
         root_prnc = mprnc["mu20"] / mprnc["mu02"]
         if root_prnc > 0:  # defaults to zero
             inert_ratio_prnc[ii] = np.sqrt(root_prnc)
+        valid[ii] = True
 
     return {
         "deform": deform,
@@ -104,4 +108,5 @@ def moments_based_features(mask, pixel_size):
         "inert_ratio_cvx": inert_ratio_cvx,
         "inert_ratio_raw": inert_ratio_raw,
         "inert_ratio_prnc": inert_ratio_prnc,
+        "valid": valid,
     }

--- a/dcnum/feat/queue_event_extractor.py
+++ b/dcnum/feat/queue_event_extractor.py
@@ -183,8 +183,18 @@ class QueueEventExtractor:
 
         # removing events with invalid legacy features
         valid_events = {}
+        # the valid key-value pair was added in `moments_based_features` and
+        # its only purpose is to mark events with invalid contours as such,
+        # so they can be removed here. Resolves issue #9.
         valid = gated_events.pop("valid")
-        if not np.all(valid):
+        invalid = ~valid
+        # The following might lead to a computational overhead, if only a few
+        # events are invalid, because then all 2d-features need to be copied
+        # over from gated_events to valid_events. According to our experience
+        # invalid events happen rarely though.
+        if np.any(invalid):
+            self.logger.info(f"Discarded {np.sum(invalid)} events due to "
+                             "invalid segmentation.")
             for key in gated_events:
                 valid_events[key] = gated_events[key][valid]
         else:

--- a/dcnum/feat/queue_event_extractor.py
+++ b/dcnum/feat/queue_event_extractor.py
@@ -144,7 +144,7 @@ class QueueEventExtractor:
     @classmethod
     def get_ppid_from_kwargs(cls, kwargs):
         """Return the pipeline ID for this event extractor"""
-        key = ""
+        key = "legacy"
         cback = kwargs_to_ppid(cls, "get_events_from_masks", kwargs)
         return ":".join([key, cback])
 

--- a/dcnum/feat/queue_event_extractor.py
+++ b/dcnum/feat/queue_event_extractor.py
@@ -144,7 +144,7 @@ class QueueEventExtractor:
     @classmethod
     def get_ppid_from_kwargs(cls, kwargs):
         """Return the pipeline ID for this event extractor"""
-        key = "legacy"
+        key = ""
         cback = kwargs_to_ppid(cls, "get_events_from_masks", kwargs)
         return ":".join([key, cback])
 
@@ -181,7 +181,7 @@ class QueueEventExtractor:
         else:
             gated_events = events
 
-        # removing events with invalid legacy features
+        # removing events with invalid features
         valid_events = {}
         # the valid key-value pair was added in `moments_based_features` and
         # its only purpose is to mark events with invalid contours as such,

--- a/dcnum/feat/queue_event_extractor.py
+++ b/dcnum/feat/queue_event_extractor.py
@@ -181,7 +181,16 @@ class QueueEventExtractor:
         else:
             gated_events = events
 
-        return gated_events
+        # removing events with invalid legacy features
+        valid_events = {}
+        valid = gated_events.pop("valid")
+        if not np.all(valid):
+            for key in gated_events:
+                valid_events[key] = gated_events[key][valid]
+        else:
+            valid_events = gated_events
+
+        return valid_events
 
     def get_masks_from_label(self, label):
         """Get masks, performing mask-based gating"""

--- a/dcnum/meta/ppid.py
+++ b/dcnum/meta/ppid.py
@@ -8,7 +8,7 @@ import pathlib
 
 #: Increment this string if there are breaking changes that make
 #: previous pipelines unreproducible.
-DCNUM_PPID_GENERATION = "3"
+DCNUM_PPID_GENERATION = "4"
 
 
 def compute_pipeline_hash(bg_id, seg_id, feat_id, gate_id,

--- a/tests/test_feat_moments_based.py
+++ b/tests/test_feat_moments_based.py
@@ -106,6 +106,26 @@ def test_mask_1d_large():
     assert np.isnan(data["area_um"][0])
 
 
+def test_mask_1d_large_no_border():
+    masks = np.array([
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+    ], dtype=bool)[np.newaxis]
+    data = feat_moments.moments_based_features(
+                mask=masks,
+                pixel_size=0.2645
+            )
+    assert data["deform"].shape == (1,)
+    assert np.isnan(data["deform"][0])
+    assert np.isnan(data["area_um"][0])
+
+
 def test_mask_2d():
     masks = np.array([
         [0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
This MR resolves the issue where sometimes a segmentation run on a dataset produced `nan`-values in the legacy features.
In short, for every event this sets a valid/invalid flag which enables us to later sort out the invalid cases and therefore remove potential `nan`-values in the features.

In the function `moments_based_features()` in `mt_legacy.py` I decided to use `valid` instead of `invalid`. I think it is better to only change the boolean value (whether it is called `invalid` or `valid`) in one place instead of multiple one. Therefore I decided not to set `invalid` to `True` in all invalid cases (which would mean I would need to add this line for every `continue`-case in the for-loop, also for future ones), but instead only set `valid` to True at the end of the current iteration. IMO this is less cluttered and easier for future `continue`-statements as they don't have to set the `(in)valid`-flag, but can only use `continue` to set this iteration to (in)valid.